### PR TITLE
update rustls && move bin to examples

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,14 +11,14 @@ homepage = "https://github.com/zerospam/smtpbis"
 repository = "https://github.com/zerospam/smtpbis.git"
 
 [dependencies]
-rustyknife = {version="0.2", features=["quoted-string-rfc2047"]}
+rustyknife = { git = "https://github.com/Tsai002/rustyknife.git" }
 tokio = {version="1.0", features=["signal", "io-util", "sync", "signal", "net", "rt-multi-thread"]}
-tokio-util = {version="0.6", features=["codec"]}
-bytes = "1.0"
-async-trait = "0.1.10"
+tokio-util = {version="0.7.1", features=["codec"]}
+bytes = "1.1.0"
+async-trait = "0.1.53"
 futures = "0.3"
 futures-util = "0.3"
 
 [dev-dependencies]
-rustls-pemfile = "0.2"
+rustls-pemfile = "0.3"
 tokio-rustls = "0.23"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,5 +17,6 @@ tokio-util = {version="0.6", features=["codec"]}
 bytes = "1.0"
 futures = "0.3"
 futures-util = "0.3"
-tokio-rustls = "0.22"
+tokio-rustls = "0.23"
 async-trait = "0.1.10"
+rustls-pemfile = "0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,8 +15,10 @@ rustyknife = {version="0.2", features=["quoted-string-rfc2047"]}
 tokio = {version="1.0", features=["signal", "io-util", "sync", "signal", "net", "rt-multi-thread"]}
 tokio-util = {version="0.6", features=["codec"]}
 bytes = "1.0"
+async-trait = "0.1.10"
 futures = "0.3"
 futures-util = "0.3"
-tokio-rustls = "0.23"
-async-trait = "0.1.10"
+
+[dev-dependencies]
 rustls-pemfile = "0.2"
+tokio-rustls = "0.23"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ bytes = "1.1.0"
 async-trait = "0.1.53"
 futures = "0.3"
 futures-util = "0.3"
+base64 = "0.13.0"
 
 [dev-dependencies]
 rustls-pemfile = "0.3"

--- a/README.md
+++ b/README.md
@@ -17,3 +17,9 @@ Features:
 
 [rustyknife]: https://crates.io/crates/rustyknife
 [tokio]: https://tokio.rs/
+
+## Usage
+
+```
+cargo run --example smtpbis-server
+```

--- a/examples/smtpbis-server.rs
+++ b/examples/smtpbis-server.rs
@@ -18,10 +18,9 @@ use tokio::net::{TcpListener, TcpStream};
 use tokio::runtime::Runtime;
 use tokio::sync::oneshot::Receiver;
 
-use tokio_rustls::rustls::{
-    internal::pemfile::{certs, rsa_private_keys},
-    NoClientAuth, ServerConfig, ServerSession, Session,
-};
+use rustls_pemfile::{certs, rsa_private_keys};
+use tokio_rustls::rustls::{Certificate, PrivateKey};
+use tokio_rustls::rustls::{ServerConfig, ServerConnection};
 use tokio_rustls::TlsAcceptor;
 
 use rustyknife::rfc5321::{ForwardPath, Param, Path, ReversePath};
@@ -31,8 +30,8 @@ use smtpbis::{
     ShutdownSignal,
 };
 
-const CERT: &[u8] = include_bytes!("../../../data/testcert.pem");
-const KEY: &[u8] = include_bytes!("../../../data/testcert.key");
+const CERT: &[u8] = include_bytes!("../data/testcert.pem");
+const KEY: &[u8] = include_bytes!("../data/testcert.key");
 
 struct DummyHandler {
     tls_config: Arc<ServerConfig>,
@@ -46,7 +45,7 @@ struct DummyHandler {
 #[async_trait]
 impl Handler for DummyHandler {
     type TlsConfig = Arc<ServerConfig>;
-    type TlsSession = ServerSession;
+    type TlsSession = ServerConnection;
 
     async fn tls_request(&mut self) -> Option<Self::TlsConfig> {
         Some(self.tls_config.clone())
@@ -55,8 +54,8 @@ impl Handler for DummyHandler {
     async fn tls_started(&mut self, session: &Self::TlsSession) {
         println!(
             "TLS started: {:?}/{:?}",
-            session.get_protocol_version(),
-            session.get_negotiated_ciphersuite()
+            session.protocol_version(),
+            session.negotiated_cipher_suite()
         );
         self.reset_tx();
     }
@@ -181,10 +180,17 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 async fn listen_loop(mut shutdown: Receiver<()>) {
     let listener = TcpListener::bind("127.0.0.1:8080").await.unwrap();
 
-    let mut tls_config = ServerConfig::new(NoClientAuth::new());
     let certs = certs(&mut Cursor::new(CERT)).unwrap();
+    let certificates: Vec<Certificate> = certs.into_iter().map(Certificate).collect();
     let key = rsa_private_keys(&mut Cursor::new(KEY)).unwrap().remove(0);
-    tls_config.set_single_cert(certs, key).unwrap();
+
+    let tls_config = ServerConfig::builder()
+        .with_safe_defaults()
+        .with_no_client_auth()
+        .with_single_cert(certificates, PrivateKey(key))
+        .expect("bad certificate/key");
+
+    // tls_config.set_single_cert(certs, key).unwrap();
     let tls_config = Arc::new(tls_config);
     let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel::<()>();
     let shutdown_rx = shutdown_rx.map_err(|_| ()).shared();

--- a/examples/smtpbis-server.rs
+++ b/examples/smtpbis-server.rs
@@ -68,6 +68,7 @@ impl Handler for DummyHandler {
         initial_keywords.insert("DSN".into(), None);
         initial_keywords.insert("8BITMIME".into(), None);
         initial_keywords.insert("SIZE".into(), Some("73400320".into()));
+        initial_keywords.insert("AUTH".into(), Some("PLAIN".into()));
 
         let greet = format!("hello {} from {}", domain, self.addr);
         self.helo = Some(domain);
@@ -81,6 +82,24 @@ impl Handler for DummyHandler {
         self.reset_tx();
 
         None
+    }
+
+    async fn auth(&mut self, auth_msg: String) -> Option<Reply> {
+        if let Ok(auth_msg) = base64::decode(auth_msg) {
+            let auth_raw = String::from_utf8_lossy(&auth_msg);
+            let auth_parts: Vec<&str> = auth_raw.split('\0').collect();
+            println!("authorization_identity: {:?}", auth_parts[0]);
+            println!("authentication_identity: {:?}", auth_parts[1]);
+            println!("password: {:?}", auth_parts[2]);
+
+            if true {
+                Some(Reply::new(235, None, "Authentication successful"))
+            } else {
+                Some(Reply::new(535, None, "Authentication credentials invalid"))
+            }
+        } else {
+            Some(Reply::new(501, None, "Base64-decode failed"))
+        }
     }
 
     async fn mail(&mut self, path: ReversePath, _params: Vec<Param>) -> Option<Reply> {

--- a/src/reply.rs
+++ b/src/reply.rs
@@ -36,6 +36,10 @@ impl Reply {
         Self::new(503, None, "Bad sequence of commands")
     }
 
+    pub fn auth_required() -> Self {
+        Self::new(530, None, "Authentication required")
+    }
+
     pub fn no_mail_transaction() -> Self {
         Self::new(503, None, "No mail transaction in progress")
     }

--- a/src/server.rs
+++ b/src/server.rs
@@ -112,7 +112,7 @@ where
 
     let res = server.serve(socket, banner).await;
     socket.flush().await?;
-    Ok(res?)
+    res
 }
 
 pub enum LoopExit<H: Handler> {

--- a/src/syntax.rs
+++ b/src/syntax.rs
@@ -1,6 +1,7 @@
 use rustyknife::nom::branch::alt;
 use rustyknife::nom::combinator::map;
 
+use rustyknife::rfc4616::command as auth_command;
 use rustyknife::rfc5321::{
     bdat_command, command as base_command, starttls_command, Command as BaseCommand, UTF8Policy,
 };
@@ -17,6 +18,7 @@ pub enum Command {
 pub enum Ext {
     STARTTLS,
     BDAT(u64, bool),
+    AUTH(String),
     XFORWARD(Vec<XforwardParam>),
 }
 
@@ -29,6 +31,9 @@ pub fn command<P: UTF8Policy>(input: &[u8]) -> NomResult<'_, Command> {
         }),
         map(xforward_command, |params| {
             Command::Ext(Ext::XFORWARD(params))
+        }),
+        map(auth_command::<P>, |s| {
+            Command::Ext(Ext::AUTH(s.to_string()))
         }),
     ))(input)
 }


### PR DESCRIPTION
First, I want to appreciate your great work. I have tried almost all rust mail crate. I haven't choose smtpbis in the beginning because it doesn't look attraction at first glance. After a lot of time wasted, I gave up another crate which looked very charming. Eventually, I found this crate's api is very elegant. Thank you again.

I think it needs more documentation, or a lot more people would miss it as I have.

### tokio-rustls update

I upgraded tokio-rustls to 0.23 from 0.22 which a lot api breaks happened. The update benefits a lot, which will remove a lot of duplication.

`cargo tree -d`

```
nom v6.1.2
└── rustyknife v0.2.11
    ├── mailsaver v0.1.0 
    └── smtpbis v0.1.7
        └── mailsaver v0.1.0 

nom v7.1.0
└── lettre v0.10.0-rc.4
    └── mailsaver v0.1.0 

rustls v0.19.1
└── tokio-rustls v0.22.0
    ├── mailsaver v0.1.0 
    └── smtpbis v0.1.7 (*)

rustls v0.20.2
├── lettre v0.10.0-rc.4 (*)
└── tokio-rustls v0.23.2
    └── lettre v0.10.0-rc.4 (*)

sct v0.6.1
└── rustls v0.19.1 (*)

sct v0.7.0
└── rustls v0.20.2 (*)

tokio-rustls v0.22.0 (*)

tokio-rustls v0.23.2 (*)

webpki v0.21.4
├── rustls v0.19.1 (*)
└── tokio-rustls v0.22.0 (*)

webpki v0.22.0
├── rustls v0.20.2 (*)
├── tokio-rustls v0.23.2 (*)
└── webpki-roots v0.22.2
    └── lettre v0.10.0-rc.4 (*)
```  

### move bin/ to examples/

As a crate, I think it should be thin. The bin actually workes as an example, so I moved it and added a little doc in README.md

And I have tested it locally.